### PR TITLE
Remove streamline-runtime dependency; use fibers directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ function printDiskUsage(dir) {
 }
 
 run(() => printDiskUsage(process.cwd()))
-    .then(() => {}, err => { throw err; });
+    .then(() => {}, err => { console.error(err); });
 ```
 
 Note: this is not a very efficient implementation because the logic is completely
@@ -67,7 +67,7 @@ async function printDiskUsage(dir) {
 }
 
 printDiskUsage(process.cwd())
-    .then(() => {}, err => { throw err; });
+    .then(() => {}, err => { console.error(err); });
 ```
 
 Two observations:
@@ -161,7 +161,7 @@ won't be called, and no other operation will enter the funnel.
   `array = q.contents()`: returns a copy of the queue's contents.  
   `q.adjust(fn[, thisObj])`: adjusts the contents of the queue by calling `newContents = fn(oldContents)`.  
   `q.length`: number of items currently in the queue.  
-
+ 
 ### CLS (Continuation Local Storage)
 
 * `cx = fpromise.context()`  
@@ -171,6 +171,33 @@ won't be called, and no other operation will enter the funnel.
   wraps a function so that it executes with context `cx` (or a wrapper around current context if `cx` is falsy).
   The previous context will be restored when the function returns (or throws).  
   returns the wrapped function.
+
+### Miscellaneous
+
+* `results = fpromise.map(collection, fn)`  
+  creates as many coroutines with `fn` as items in `collection` and wait for them to finish to return result array.
+ 
+* `fpromise.sleep(ms)`  
+  suspends current coroutine for `ms` milliseconds.
+ 
+* `ok = fpromise.canWait()`  
+  returns whether `wait` calls are allowed (whether we are called from a `run`).
+    
+* `wrapped = fpromise.eventHandler(handler)`  
+  wraps `handler` so that it can call `wait`.  
+  the wrapped handler will execute on the current fiber if canWait() is true.
+  otherwise it will be `run` on a new fiber (without waiting for its completion)  
+  
+### Error stack traces
+
+Three policies available for error stack trace handling:
+* `fast`: stack traces are not changed. Call history might be difficult to read; cost less.
+* `whole`: stack traces due to async tasks errors in `wait()` are concatenate with the current coroutine stack.
+  This allow to have a complete history call (including f-promise traces).
+* default: stack traces are like `whole` policy, but clean up to remove f-promise noise.
+
+The policy can be set with `FPROMISE_STACK_TRACES` environment variable.
+Any value other than `fast` and `whole` are consider as default policy. 
 
 ## Related projects
 

--- a/examples/disk-usage-async-await.ts
+++ b/examples/disk-usage-async-await.ts
@@ -17,4 +17,4 @@ async function printDiskUsage(dir: string) {
 }
 
 printDiskUsage(process.cwd())
-	.catch(err => { throw err; });
+	.catch(err => { console.error(err.stack); });

--- a/examples/disk-usage.ts
+++ b/examples/disk-usage.ts
@@ -17,4 +17,4 @@ function printDiskUsage(dir: string) {
 }
 
 run(() => printDiskUsage(process.cwd()))
-	.catch(err => { throw err; });
+	.catch(err => { console.error(err.stack); });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,10 @@
       "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
       "dev": true
     },
-    "@types/fibers": {
-      "version": "0.0.29",
-      "resolved": "http://registry.npmjs.org/@types/fibers/-/fibers-0.0.29.tgz",
-      "integrity": "sha1-TIFSCacX7eUFwwQLTjoxp/UjnUk=",
-      "dev": true
-    },
     "@types/mocha": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
-      "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
       "dev": true
     },
     "@types/mz": {
@@ -32,27 +26,9 @@
       }
     },
     "@types/node": {
-      "version": "8.10.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.37.tgz",
-      "integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig==",
-      "dev": true
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "version": "8.10.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.49.tgz",
+      "integrity": "sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w==",
       "dev": true
     },
     "any-promise": {
@@ -65,589 +41,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      }
-    },
-    "babel-core": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "babel-generator": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-      "dev": true,
-      "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
-      "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-streamline": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/babel-plugin-streamline/-/babel-plugin-streamline-2.0.26.tgz",
-      "integrity": "sha1-U7TK+6jRRYa65TYDoci6AX60HyE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "^6.3.26",
-        "colors": "^1.1.2"
-      }
-    },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
-      "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
-      }
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "dev": true,
-      "requires": {
-        "regenerator-transform": "^0.10.0"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-        "babel-plugin-transform-es2015-classes": "^6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-        "babel-plugin-transform-es2015-for-of": "^6.22.0",
-        "babel-plugin-transform-es2015-function-name": "^6.24.1",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-plugin-transform-es2015-object-super": "^6.24.1",
-        "babel-plugin-transform-es2015-parameters": "^6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-        "babel-plugin-transform-regenerator": "^6.24.1"
-      }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
-      },
-      "dependencies": {
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "^0.5.6"
-          }
-        }
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        }
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "balanced-match": {
@@ -686,41 +79,15 @@
         "type-detect": "^4.0.5"
       }
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
-    "colors": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
-    },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -728,21 +95,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "debug": {
@@ -763,14 +115,10 @@
         "type-detect": "^4.0.0"
       }
     },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "^2.0.0"
-      }
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diff": {
       "version": "3.5.0",
@@ -784,16 +132,13 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
-    },
     "fibers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-3.0.0.tgz",
-      "integrity": "sha512-cAcOHOTbTMlcpNZvr94BNFsnBDBiEu9JP5MYcRLyl12HF/X0z3KvZyNzU9+BtI8lOIaV84PlDQJOKK3f5llJug=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-3.1.1.tgz",
+      "integrity": "sha512-dl3Ukt08rHVQfY8xGD0ODwyjwrRALtaghuqGH2jByYX1wpY+nAnRQjJ6Dbqq0DnVgNVQ9yibObzbF4IlPyiwPw==",
+      "requires": {
+        "detect-libc": "^1.0.3"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -821,26 +166,11 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
-    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
     },
     "has-flag": {
       "version": "3.0.0",
@@ -853,16 +183,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
-      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -880,57 +200,6 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
-    },
-    "jsesc": {
-      "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-      "dev": true
-    },
-    "json5": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
-    },
-    "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -942,13 +211,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -991,12 +260,6 @@
         "thenify-all": "^1.0.0"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1012,21 +275,9 @@
         "wrappy": "1"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -1035,164 +286,6 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
-    },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
-    },
-    "regenerate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-      "dev": true
-    },
-    "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-    },
-    "regenerator-transform": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
-      }
-    },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "~0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
-        }
-      }
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "^1.0.0"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "git+https://github.com/Sage/node-source-map-support.git#ca4cf25ab660a84cbf489c73572f6451eafddc6e",
-      "from": "git+https://github.com/Sage/node-source-map-support.git#catch-missing-sourcemap-element",
-      "dev": true,
-      "requires": {
-        "source-map": "0.1.32"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-          "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-          "dev": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
-      }
-    },
-    "streamline": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/streamline/-/streamline-2.1.3.tgz",
-      "integrity": "sha512-UU6CSpyL7pJ3jAnieE5AUj3sFGJoA4dsRaz9iVRAwS7459rth9WmxZA59ROOs12XNEFmqxxIBdYxwyu2ep1pXg==",
-      "dev": true,
-      "requires": {
-        "babel-core": "^6.3.26",
-        "babel-plugin-streamline": "^2.0.19",
-        "babel-preset-es2015": "^6.3.13",
-        "colors": "^1.1.2",
-        "commander": "^2.8.1",
-        "source-map-support": "git+https://github.com/Sage/node-source-map-support.git#ca4cf25ab660a84cbf489c73572f6451eafddc6e",
-        "streamline-runtime": "^1.1.10",
-        "typescript": "^2.0.0"
-      }
-    },
-    "streamline-node": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/streamline-node/-/streamline-node-3.1.2.tgz",
-      "integrity": "sha512-1Z7uJF9a33CxcK3ZFPJ5uc2gihnG267jaebaIodzoGjU2yZ5q6TwiLtBvI2m0Kx3NYFPbkIVbizVxAkUazW0gw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "^8.10.34"
-      }
-    },
-    "streamline-runtime": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/streamline-runtime/-/streamline-runtime-1.2.0.tgz",
-      "integrity": "sha512-5PH0ZwF2e5Vh6xosz1kVNmCrdR6bBXxzdAZ28kaV7iPrmTGKI7B4VHOJt5mF0ZmhJcnVug/m8LcMah/lzvitNw==",
-      "requires": {
-        "colors": "^1.3.0",
-        "fibers": "^3.0.0",
-        "regenerator-runtime": "^0.10.1"
-      }
-    },
-    "streamline-typings": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/streamline-typings/-/streamline-typings-1.0.1.tgz",
-      "integrity": "sha1-te7kstfzKcWIKEhS9opnJyQ9RIc=",
-      "dev": true
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
     },
     "supports-color": {
       "version": "5.4.0",
@@ -1220,18 +313,6 @@
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
-    },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
     },
     "type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -13,21 +13,16 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "fibers": "^3.0.0",
-    "streamline-runtime": "^1.1.15"
+    "fibers": "^3.0.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",
-    "@types/fibers": "^0.0.29",
     "@types/mocha": "^5.2.4",
     "@types/mz": "0.0.32",
     "@types/node": "^8.10.34",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     "mz": "^2.7.0",
-    "streamline": "^2.1.3",
-    "streamline-node": "^3.0.0",
-    "streamline-typings": "^1.0.1",
     "typescript": "^2.9.2"
   },
   "keywords": [
@@ -41,8 +36,8 @@
     "url": "git://github.com/Sage/f-promise.git"
   },
   "scripts": {
-    "prepare": "rm -rf build && tsc && _node --runtime fibers --out-dir build -c index.ts src test examples/disk-usage.ts && tsc --target ES2015 --module commonjs --outDir build examples/disk-usage-async-await.ts",
-    "test": "mocha build/test",
+    "prepare": "rm -rf build && tsc && tsc --target ES2015 --module commonjs --outDir build examples/disk-usage-async-await.ts",
+    "test": "_mocha build/test",
     "lint": "tslint -e 'node_modules/**' -p ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "prepare": "rm -rf build && tsc && tsc --target ES2015 --module commonjs --outDir build examples/disk-usage-async-await.ts",
-    "test": "_mocha build/test",
+    "test": "mocha build/test",
     "lint": "tslint -e 'node_modules/**' -p ."
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export let run = <T>(fn: () => T): Promise<T> => {
 	}
 	return new Promise((resolve, reject) => {
 		const cx = globals.context;
-		const res = fibers(() => {
+		fibers(() => {
 			try {
 				resolve(fn());
 			} catch (e) {
@@ -83,26 +83,26 @@ export let run = <T>(fn: () => T): Promise<T> => {
 // goodies
 
 /// ## funnel
-/// * `fun = funnel(max)`  
+/// * `fun = funnel(max)`
 ///   limits the number of concurrent executions of a given code block.
-/// 
+///
 /// The `funnel` function is typically used with the following pattern:
-/// 
+///
 /// ``` ts
 /// // somewhere
 /// var myFunnel = funnel(10); // create a funnel that only allows 10 concurrent executions.
-/// 
+///
 /// // elsewhere
 /// myFunnel(function() { /* code with at most 10 concurrent executions */ });
 /// ```
-/// 
+///
 /// The `funnel` function can also be used to implement critical sections. Just set funnel's `max` parameter to 1.
-/// 
-/// If `max` is set to 0, a default number of parallel executions is allowed. 
-/// This default number can be read and set via `flows.funnel.defaultSize`.  
+///
+/// If `max` is set to 0, a default number of parallel executions is allowed.
+/// This default number can be read and set via `flows.funnel.defaultSize`.
 /// If `max` is negative, the funnel does not limit the level of parallelism.
-/// 
-/// The funnel can be closed with `fun.close()`.  
+///
+/// The funnel can be closed with `fun.close()`.
 /// When a funnel is closed, the operations that are still in the funnel will continue but their callbacks
 /// won't be called, and no other operation will enter the funnel.
 export function funnel(max = -1): Funnel {
@@ -173,13 +173,13 @@ export interface Funnel {
 	close(): void;
 }
 
-/// 
+///
 /// ## handshake and queue
-/// * `hs = handshake()`  
-///   allocates a simple semaphore that can be used to do simple handshakes between two tasks.  
-///   The returned handshake object has two methods:  
-///   `hs.wait()`: waits until `hs` is notified.  
-///   `hs.notify()`: notifies `hs`.  
+/// * `hs = handshake()`
+///   allocates a simple semaphore that can be used to do simple handshakes between two tasks.
+///   The returned handshake object has two methods:
+///   `hs.wait()`: waits until `hs` is notified.
+///   `hs.notify()`: notifies `hs`.
 ///   Note: `wait` calls are not queued. An exception is thrown if wait is called while another `wait` is pending.
 export function handshake<T = void>() {
 	let callback: Callback<T> | undefined = undefined, notified = false;
@@ -205,11 +205,11 @@ export interface Handshake<T = void> {
 	notify(): void;
 }
 
-/// * `q = new Queue(options)`  
-///   allocates a queue which may be used to send data asynchronously between two tasks.  
-///   The `max` option can be set to control the maximum queue length.  
+/// * `q = new Queue(options)`
+///   allocates a queue which may be used to send data asynchronously between two tasks.
+///   The `max` option can be set to control the maximum queue length.
 ///   When `max` has been reached `q.put(data)` discards data and returns false.
-///   The returned queue has the following methods:  
+///   The returned queue has the following methods:
 export interface QueueOptions {
 	max?: number;
 }
@@ -249,7 +249,7 @@ export class Queue<T> {
 			}
 		});
 	}
-	///   `q.write(data)`:  queues an item. Waits if the queue is full.  
+	///   `q.write(data)`:  queues an item. Waits if the queue is full.
 	write(item: T | undefined) {
 		return wait<T>((cb: Callback<T>) => {
 			if (this.put(item)) {
@@ -262,7 +262,7 @@ export class Queue<T> {
 
 		});
 	}
-	///   `ok = q.put(data)`: queues an item synchronously. Returns true if the queue accepted it, false otherwise. 
+	///   `ok = q.put(data)`: queues an item synchronously. Returns true if the queue accepted it, false otherwise.
 	put(item: T | undefined, force?: boolean) {
 		if (!this._callback) {
 			if (this._max >= 0 && this._q.length >= this._max && !force) return false;
@@ -276,19 +276,19 @@ export class Queue<T> {
 		}
 		return true;
 	}
-	///   `q.end()`: ends the queue. This is the synchronous equivalent of `q.write(_, undefined)`  
+	///   `q.end()`: ends the queue. This is the synchronous equivalent of `q.write(_, undefined)`
 	end() {
 		this.put(undefined, true);
 	}
-	///   `data = q.peek()`: returns the first item, without dequeuing it. Returns `undefined` if the queue is empty.  
+	///   `data = q.peek()`: returns the first item, without dequeuing it. Returns `undefined` if the queue is empty.
 	peek() {
 		return this._q[0];
 	}
-	///   `array = q.contents()`: returns a copy of the queue's contents.  
+	///   `array = q.contents()`: returns a copy of the queue's contents.
 	contents() {
 		return this._q.slice(0);
 	}
-	///   `q.adjust(fn[, thisObj])`: adjusts the contents of the queue by calling `newContents = fn(oldContents)`.  
+	///   `q.adjust(fn[, thisObj])`: adjusts the contents of the queue by calling `newContents = fn(oldContents)`.
 	adjust(fn: (old: (T | undefined)[]) => (T | undefined)[]) {
 		const nq = fn.call(null, this._q);
 		if (!Array.isArray(nq)) throw new Error('adjust function does not return array');
@@ -297,12 +297,12 @@ export class Queue<T> {
 	get length() { return this._q.length; }
 }
 
-/// 
+///
 /// ## Continuation local storage (CLS)
-/// 
-/// * `result = withContext(fn, cx)`  
+///
+/// * `result = withContext(fn, cx)`
 ///   wraps a function so that it executes with context `cx` (or a wrapper around current context if `cx` is falsy).
-///   The previous context will be restored when the function returns (or throws).  
+///   The previous context will be restored when the function returns (or throws).
 ///   returns the wrapped function.
 export function withContext<T>(fn: () => T, cx: any): T {
 	if (!fibers.current) throw new Error('withContext(fn) not allowed outside run()');
@@ -319,9 +319,9 @@ export function context<T = any>(): T {
 	return globals.context;
 }
 
-/// 
+///
 /// ## Miscellaneous
-/// 
+///
 /// * `results = map(collection, fn)`
 ///   creates as many coroutines with `fn` as items in `collection` and wait for them to finish to return result array.
 export function map<T, R>(collection: T[], fn: (val: T) => R) {
@@ -336,16 +336,16 @@ export function sleep(n: number): void {
 	wait(cb => setTimeout(cb, n));
 }
 
-/// * `ok = canWait()`  
+/// * `ok = canWait()`
 ///   returns whether `wait` calls are allowed (whether we are called from a `run`).
 export function canWait() {
 	return !!fibers.current;
 }
 
-/// * `wrapped = eventHandler(handler)`  
-///   wraps `handler` so that it can call `wait`.  
+/// * `wrapped = eventHandler(handler)`
+///   wraps `handler` so that it can call `wait`.
 ///   the wrapped handler will execute on the current fiber if canWait() is true.
-///   otherwise it will be `run` on a new fiber (without waiting for its completion)  
+///   otherwise it will be `run` on a new fiber (without waiting for its completion)
 export function eventHandler<T extends Function>(handler: T): T {
 	const wrapped = function(this: any, ...args: any[]) {
 		if (canWait()) handler.apply(this, args);
@@ -373,9 +373,9 @@ let cleanFiberStack: ((e: Error) => Error) | undefined;
 /// * `whole`: stack traces due to async tasks errors in `wait()` are concatenate with the current coroutine stack.
 ///   This allow to have a complete history call (including f-promise traces).
 /// * default: stack traces are like `whole` policy, but clean up to remove f-promise noise.
-/// 
+///
 /// The policy can be set with `FPROMISE_STACK_TRACES` environment variable.
-/// Any value other than `fast` and `whole` are consider as default policy. 
+/// Any value other than `fast` and `whole` are consider as default policy.
 if (process.env.FPROMISE_STACK_TRACES === 'whole') {
 
 	fullStackError = function fullStackError(e: Error) {
@@ -437,7 +437,7 @@ if (process.env.FPROMISE_STACK_TRACES === 'whole') {
 // So we monkey patch wait to throw an exception if it detects this special situation.
 if (process.execArgv.find(str => str.startsWith('--inspect-brk'))) {
 	// Unfortunately, there is no public API to check if we are called from a breakpoint.
-	// There is a C++ API (context->IsDebugEvaluateContext()) to test this 
+	// There is a C++ API (context->IsDebugEvaluateContext()) to test this
 	// but unfortunately this is an internal V8 API.
 	// This test is the best workaround I have found.
 	const isDebugEval = () => (new Error().stack || '').indexOf('.remoteFunction (<anonymous>') >= 0;
@@ -455,18 +455,24 @@ if (process.execArgv.find(str => str.startsWith('--inspect-brk'))) {
 		}
 	};
 
+	// Why throw string (from bjouhier)
+	// I think I threw a string rather than an Error object because
+	// I did not want to clutter the debugger with error objects.
+	// There was also a memory issue here: debugger allocating a lot
+	// of Error objects and stack trace captures vs. a string literal
+	// which does not require any dynamic memory allocation.
 	wait = <T>(arg: Promise<T> | Thunk<T>): T => {
 		if (isDebugEval()) {
 			if (!fibers.current.delayed) fibers.current.delayed = [];
 			fibers.current.delayed.push(arg);
-			throw new Error('would yield');
+			throw 'would yield';
 		}
 		flushDelayed();
 		return oldWait(arg);
 	};
 	const oldRun = run;
 	run = <T>(fn: () => T): Promise<T> => {
-		if (isDebugEval()) throw new Error('would start a fiber');
+		if (isDebugEval()) throw 'would start a fiber';
 		else return oldRun(fn);
 	};
 	console.log('Running with f-promise debugger hooks');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,31 +1,82 @@
-// Very thin implementation. Streamline.js does all the work.
-import { _ } from 'streamline-runtime';
 const fibers = require('fibers');
 
 export type Callback<T> = (err: any, result?: T) => void;
 export type Thunk<T> = (cb: Callback<T>) => void;
 
-export let wait = <T>(arg: Promise<T> | Thunk<T>): T => {
-	if (typeof arg === 'function') {
-		// fiberized test optimizes calls to streamlined thunks: (_: _) => T 
-		const fiberized = (arg as any)['fiberized-0'];
-		if (fiberized) return fiberized(true);
-		else return wait(_.promise(_ => _.cast<T>(arg as any)(_)));
+///
+/// ## run/wait
+/// * `promise = run(() => { wait(promise/callback); ... })`
+///    create a coroutine to write asynchronous code in a synchronous way.
+///
+/// All the job is done by fibers library.
+/// Those two functions are the core, others are goodies:
+///   * `promise = run(fn)` create a coroutine.
+///     This start a fiber, which is stopped when `fn` returns.
+///   * `result = wait(promise/callback)` encapsulate promise or callback.
+///     Concretely, the fiber is suspended while the asynchronous task is not finished, then it resumes.
+///     As many `wait()` as needed may be used in a run.
+export let wait = <T = any>(promiseOrCallback: Promise<T> | Thunk<T>): T => {
+	const fiber = fibers.current;
+	if (typeof promiseOrCallback === 'function') {
+		promiseOrCallback((err, res) => {
+			let cx = globals.context;
+			try {
+				if (err) {
+					fiber.throwInto(err);
+				} else {
+					fiber.run(res);
+				}
+			} finally {
+				globals.context = cx;
+				cx = null;
+			}
+		});
 	} else {
-		const streamlined = ((_: _) => arg.then(_, _));
-		return (streamlined as any)['fiberized-0'].call(null, true);
+		promiseOrCallback.then(res => {
+			let cx = globals.context;
+			try {
+				fiber.run(res);
+			} finally {
+				globals.context = cx;
+				cx = null;
+			}
+		}).catch(e => {
+			let cx = globals.context;
+			try {
+				fiber.throwInto(e);
+			} finally {
+				globals.context = cx;
+				cx = null;
+			}
+		});
 	}
-}
+	let cx = globals.context;
+	try {
+		return fibers.yield();
+	} catch (e) {
+		throw fullStackError && fullStackError(e) || e;
+	} finally {
+		globals.context = cx;
+		cx = null;
+	}
+};
 
 export let run = <T>(fn: () => T): Promise<T> => {
-	return _.promise((_: _) => fn());
-}
-
-export function map<T, R>(collection: T[], fn: (val: T) => R) {
-	return collection.map(item => {
-		return run(() => fn(item));
-	}).map(wait);
-}
+	if (typeof fn !== 'function') {
+		throw new Error('run() should take a function as argument');
+	}
+	return new Promise((resolve, reject) => {
+		const cx = globals.context;
+		const res = fibers(() => {
+			try {
+				resolve(fn());
+			} catch (e) {
+				reject(cleanFiberStack && cleanFiberStack(e) || e);
+			}
+		}).run();
+		globals.context = cx;
+	});
+};
 
 // goodies
 
@@ -52,10 +103,72 @@ export function map<T, R>(collection: T[], fn: (val: T) => R) {
 /// The funnel can be closed with `fun.close()`.  
 /// When a funnel is closed, the operations that are still in the funnel will continue but their callbacks
 /// won't be called, and no other operation will enter the funnel.
-export function funnel(n: number): <T>(fn: () => T) => T;
-export function funnel(n: number): <T>(fn: () => T | undefined) => T | undefined {
-	const fun = _.funnel(n);
-	return fn => wait(_ => fun(_ as any, (_: _) => fn()));
+export function funnel<T = void>(max = -1): Funnel<T> {
+	if (typeof max !== 'number') {
+		throw new Error('bad max number: ' + max);
+	}
+
+	const _max = (max === 0) ? exports.funnel.defaultSize : max;
+	
+	// Each bottled coroutine use an handshake to be waked up later when an other quit.
+	// Before waiting on the handshake, it is pushed to this queue.
+	let queue: Handshake[] = [];
+	let active = 0;
+	let closed = false;
+
+	function tryEnter(fn: () => T) {
+		if (active < _max) {
+			active++;
+			try {
+				fn();
+			} finally {
+				active--;
+				const hk = queue.shift();
+				if (hk) {
+					hk.notify();
+				}
+			}
+		} else {
+			overflow(fn);
+		}
+	}
+
+	function overflow(fn: () => T) {
+		const hk = handshake();
+		queue.push(hk);
+		hk.wait();
+		if (closed) {
+			return;
+		}
+		// A success is not sure, the entry ticket may have already be taken by another,
+		// so this one may still be delayed by re-entering in overflow().
+		tryEnter(fn);
+	}
+
+	const fun = function(fn: () => T) {
+		if (closed) {
+			return;
+		}
+		if (_max < 0 || _max === Infinity) {
+			return fn();
+		}
+		return tryEnter(fn);
+	} as Funnel<T>;
+	
+	fun.close = () => {
+		queue.forEach(hk => {
+			hk.notify();
+		});
+		queue = [];
+		closed = true;
+	};
+	return fun;
+}
+(funnel as any).defaultSize = 4;
+
+export interface Funnel<T = void> {
+	(fn: () => T): T;
+	close(): void;
 }
 
 /// 
@@ -66,7 +179,7 @@ export function funnel(n: number): <T>(fn: () => T | undefined) => T | undefined
 ///   `hs.wait()`: waits until `hs` is notified.  
 ///   `hs.notify()`: notifies `hs`.  
 ///   Note: `wait` calls are not queued. An exception is thrown if wait is called while another `wait` is pending.
-export function handshake<T>() {
+export function handshake<T = void>() {
 	let callback: Callback<T> | undefined = undefined, notified = false;
 	return {
 		wait() {
@@ -83,6 +196,11 @@ export function handshake<T>() {
 			callback = undefined;
 		},
 	};
+}
+
+export interface Handshake<T = void> {
+	wait(): void;
+	notify(): void;
 }
 
 /// * `q = new Queue(options)`  
@@ -184,38 +302,50 @@ export class Queue<T> {
 ///   wraps a function so that it executes with context `cx` (or a wrapper around current context if `cx` is falsy).
 ///   The previous context will be restored when the function returns (or throws).  
 ///   returns the wrapped function.
-export function withContext<T>(fn: () => T, cx: any) {
+export function withContext<T>(fn: () => T, cx: any): T {
 	if (!fibers.current) throw new Error('withContext(fn) not allowed outside run()');
-	return _.withContext(fn, cx)();
+	const oldContext = globals.context;
+	globals.context = cx || Object.create(oldContext);
+	try {
+		return fn();
+	} finally {
+		globals.context = oldContext;
+	}
 }
 
-export function context() {
-	return _.context;
-}
-
-// wait variant for streamline.js
-// Callback parameter is typed as any so that f-promise does not re-export streamline-runtime's _ definition.
-export function wait_<T>(arg: (_: any) => T): T {
-	const fiberized = (arg as any)['fiberized-0'];
-	return fiberized(true);
+export function context<T = any>(): T {
+	return globals.context;
 }
 
 /// 
 /// ## Miscellaneous
 /// 
+/// * `results = map(collection, fn)`
+///   creates as many coroutines with `fn` as items in `collection` and wait for them to finish to return result array.
+export function map<T, R>(collection: T[], fn: (val: T) => R) {
+	return collection.map(item => {
+		return run(() => fn(item));
+	}).map(wait);
+}
+
+/// * `sleep(ms)`
+///   suspends current coroutine for `ms` milliseconds.
+export function sleep(n: number): void {
+	wait(cb => setTimeout(cb, n));
+}
+
 /// * `ok = canWait()`  
 ///   returns whether `wait` calls are allowed (whether we are called from a `run`).
 export function canWait() {
 	return !!fibers.current;
 }
 
-/// 
 /// * `wrapped = eventHandler(handler)`  
 ///   wraps `handler` so that it can call `wait`.  
-///   the wrapped handler will excute on the current fiber if canWait() is true.
+///   the wrapped handler will execute on the current fiber if canWait() is true.
 ///   otherwise it will be `run` on a new fiber (without waiting for its completion)  
 export function eventHandler<T extends Function>(handler: T): T {
-	const wrapped = function (this: any, ...args: any[]) {
+	const wrapped = function(this: any, ...args: any[]) {
 		if (canWait()) handler.apply(this, args);
 		else run(() => withContext(() => handler.apply(this, args), {})).catch(err => { console.error(err); });
 	} as any;
@@ -224,10 +354,86 @@ export function eventHandler<T extends Function>(handler: T): T {
 	return wrapped;
 }
 
+// private
+
+declare const global: any;
+const secret = '_20c7abceb95c4eb88b7ca1895b1170d1';
+const globals = (global[secret] = (global[secret] || { context: {} }));
+
+// Those functions are conditionally assigned bellow.
+let fullStackError: ((e: Error) => Error) | undefined;
+let cleanFiberStack: ((e: Error) => Error) | undefined;
+
+/// ## Error stack traces
+///
+/// Three policies:
+/// * `fast`: stack traces are not changed. Call history might be difficult to read; cost less.
+/// * `whole`: stack traces due to async tasks errors in `wait()` are concatenate with the current coroutine stack.
+///   This allow to have a complete history call (including f-promise traces).
+/// * default: stack traces are like `whole` policy, but clean up to remove f-promise noise.
+/// 
+/// The policy can be set with `FPROMISE_STACK_TRACES` environment variable.
+/// Any value other than `fast` and `whole` are consider as default policy. 
+if (process.env.FPROMISE_STACK_TRACES === 'whole') {
+
+	fullStackError = function fullStackError(e: Error) {
+		if (!(e instanceof Error)) {
+			return e;
+		}
+		const localError = new Error('__fpromise');
+		const fiberStack = e.stack || '';
+		Object.defineProperty(e, 'stack', {
+			get: function() {
+				const localStack = localError ? localError.stack || '' : '';
+				return fiberStack + localStack;
+			},
+			enumerable: true,
+		});
+		return e;
+	};
+
+} else if (process.env.FPROMISE_STACK_TRACES !== 'fast') {
+
+	fullStackError = function fullStackError(e: Error) {
+		if (!(e instanceof Error)) {
+			return e;
+		}
+		const localError = new Error('__f-promise');
+		const fiberStack = e.stack || '';
+		Object.defineProperty(e, 'stack', {
+			get: function() {
+				const localStack = localError ? localError.stack || '' : '';
+				return (fiberStack + '\n' + localStack.split('\n').slice(1).filter(line => {
+					return !/\bf-promise\/build\/src\/\b/.test(line);
+				}).join('\n'));
+			},
+			enumerable: true,
+		});
+		return e;
+	};
+
+	cleanFiberStack = function cleanFiberStack(e: Error) {
+		if (!(e instanceof Error)) {
+			return e;
+		}
+		const fiberStack = e.stack || '';
+		Object.defineProperty(e, 'stack', {
+			get: function() {
+				return fiberStack.split('\n').filter(line => {
+					return !/\bf-promise\/build\/src\/\b/.test(line);
+				}).join('\n');
+			},
+			enumerable: true,
+		});
+		return e;
+	};
+
+}
+
 // little goodie to improve V8 debugger experience
 // The debugger hangs if Fiber.yield is called when evaluating expressions at a breakpoint
 // So we monkey patch wait to throw an exception if it detects this special situation.
-if (process.execArgv.find(str => str.startsWith('--inspect-brk='))) {
+if (process.execArgv.find(str => str.startsWith('--inspect-brk'))) {
 	// Unfortunately, there is no public API to check if we are called from a breakpoint.
 	// There is a C++ API (context->IsDebugEvaluateContext()) to test this 
 	// but unfortunately this is an internal V8 API.
@@ -245,21 +451,20 @@ if (process.execArgv.find(str => str.startsWith('--inspect-brk='))) {
 				catch (err) { console.error(`delayed 'wait' call failed: ${err.message}`); }
 			}
 		}
-	}
+	};
 
 	wait = <T>(arg: Promise<T> | Thunk<T>): T => {
 		if (isDebugEval()) {
 			if (!fibers.current.delayed) fibers.current.delayed = [];
 			fibers.current.delayed.push(arg);
-			throw 'would yield';
-		} else {
-			flushDelayed();
-			return oldWait(arg);
+			throw new Error('would yield');
 		}
+		flushDelayed();
+		return oldWait(arg);
 	};
 	const oldRun = run;
 	run = <T>(fn: () => T): Promise<T> => {
-		if (isDebugEval()) throw 'would start a fiber';
+		if (isDebugEval()) throw new Error('would start a fiber');
 		else return oldRun(fn);
 	};
 	console.log('Running with f-promise debugger hooks');

--- a/test/f-promise-test.ts
+++ b/test/f-promise-test.ts
@@ -163,15 +163,15 @@ describe('handshake', () => {
 	test('multiple wait fails', () => {
 		const hk = handshake();
 		let thrown = false;
-		function runAntWait() {
+		function runAndWait() {
 			run(() => {
 				hk.wait();
 			}).catch(e => {
 				thrown = true;
 			});
 		}
-		runAntWait();
-		runAntWait();
+		runAndWait();
+		runAndWait();
 		sleep(10);
 		hk.notify(); // release not thrown run
 		equal(thrown, true);


### PR DESCRIPTION
- full wait/run rewrite directly based on fibers
- remove wait_ function
- full funnel rewrite, with handshake usage
- add type Handshake<T> and Funnel<T>
- full rewrite of context and withContext functions
- add sleep goodie
- add some test cases
- nice error stack traces with several policies,
  configured with FPROMISE_STACK_TRACES env var
- fix debug hack to accept --inspect-brk
- fix examples when exception are thrown
- minor lint fixes

Huge cpu and memory usage optimisation with these kind of stress test:
Many run in concurrence that does many setTimeout wait.
https://gist.github.com/sberthier/38eb29adf89b461f7a017d74727d432d

Globaly, optime is hard to estimate as it depends on the nature of the app.
But for an api that receive many connections and creates a fiber for each, I am sure it will be noticeable.

I tested it on a small project that use it widly. But I will test it on another bigger project soon.

Both current and this implementation are compatible. I use f-streams that has not this update on the stress test and on my project.

@tchambard 